### PR TITLE
Use public git URLs, otherwise your test suite hangs up

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/mohiva-common"]
 	path = vendor/mohiva-common
-	url = git@github.com:mohiva/common.git
+	url = git://github.com/mohiva/common.git


### PR DESCRIPTION
Use public git URLs, otherwise your test suite hangs up waiting for input on travis-ci.org
